### PR TITLE
Console: allow usage if installed as dependency

### DIFF
--- a/bin/transphpile
+++ b/bin/transphpile
@@ -9,7 +9,7 @@ set_error_handler(function ($severity, $message, $file, $line) {
     }
 });
 
-if (file_exists($path = __DIR__.'/../vendor/autoload.php')) {
+if (file_exists($path = __DIR__.'/../vendor/autoload.php') || file_exists($path = __DIR__.'/../../../../vendor/autoload.php')) {
     require_once $path;
 } else {
     fwrite(STDERR, "Error: please run 'composer install' to install dependencies\n");


### PR DESCRIPTION
This change allows usage of the console `bin/transphpile` if the package was installed via composer as a dependency.

Explanation:
Installing the package with composer `composer require jaytaph/Transphpile` (if you add it as repository first) will symlink `bin/transphpile` into `vendor/bin/transphpile`.