### PR TITLE
Convert double calls into call_user_func

### DIFF
--- a/lib/Transphpile/Tests/Functional/tests/doublecall001.yml
+++ b/lib/Transphpile/Tests/Functional/tests/doublecall001.yml
@@ -1,0 +1,30 @@
+---
+name: Calling where function used is the result of a call
+stdout: |
+  "v"42\["a","b","c"\]
+code: |
+  declare(strict_types=1);
+
+  function test1() {
+    return function($arg) { return json_encode($arg);};
+  }
+
+  class C{
+    function test2() {
+      return function($arg, $arg2) { return $arg + $arg2; };
+    }
+  }
+
+  class D{
+      public $arg;
+      public function __construct($arg) {
+          $this->arg = $arg;
+      }
+      public function __invoke($arg2, $arg3) {
+          return json_encode([$this->arg, $arg2, $arg3]);
+      }
+  }
+
+  echo test1()("v");
+  echo C::test2()(20, 22);
+  echo (new D('a'))('b','c');

--- a/lib/Transphpile/Transpile/Visitors/Php70/DoubleCallVisitor.php
+++ b/lib/Transphpile/Transpile/Visitors/Php70/DoubleCallVisitor.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Transphpile\Transpile\Visitors\Php70;
+
+use PhpParser\Node;
+use PhpParser\NodeVisitorAbstract;
+use PhpParser\ParserFactory;
+
+
+/*
+ * Converts foo(a1)(a2, a3) into;
+ *
+ *      call_user_func(
+ *          foo(a1),
+ *          a2,
+ *          a3
+ *      )
+ */
+
+class DoubleCallVisitor extends NodeVisitorAbstract
+{
+    public function leaveNode(Node $node)
+    {
+        if (!$node instanceof Node\Expr\FuncCall) {
+            return null;
+        }
+
+        $name = $node->name;
+        if (!$name instanceof Node\Expr) {
+            return null;
+        }
+        // Can't call ClassName::foo(type)(args) or (new Visitor())(args) in php5
+        if (($name instanceof Node\Expr\MethodCall) ||
+            ($name instanceof Node\Expr\StaticCall) ||
+            ($name instanceof Node\Expr\FuncCall) ||
+            ($name instanceof Node\Expr\New_)) {
+
+            // Create call_user_func() call
+            return new Node\Expr\FuncCall(
+                new Node\Name('call_user_func'),
+                array_merge(
+                    array($name),
+                    $node->args
+                )
+            );
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
(There may be a more generic way to do this,
 but I'm mostly focusing on constructors/methods returning callables)

E.g.

- `(new SomethingVisitor())($arg1, $arg2)`
  becomes call_user_func(new SomethingVisitor(), $arg1, $arg2)
- `MyClass::makeCallable($constructorArgs)($args)`
- makeCallable($constructorArgs)($args)`