### PR TITLE
Only evaluate right hand side of `??` if left value is null

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ matrix:
     - php: nightly
   fast_finish: true
 
-script: vendor/bin/phpunit
+script: PHPRC=$PWD/lib/Transphpile/Tests/phprc vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: php
 
 sudo: false
+# Fixes "HHVM is no longer supported on Ubuntu Precise. Please consider using Trusty with `dist: trusty`."
+dist: trusty
 
 php:
   - 5.4

--- a/lib/Transphpile/Tests/Functional/tests/define001.yml
+++ b/lib/Transphpile/Tests/Functional/tests/define001.yml
@@ -2,11 +2,11 @@
 name: Test if array defines work
 stdout: |
   array\(3\) \{
-    \[0\] =>
+    \[0\]\s*=>
     string\(3\) "dog"
-    \[1\] =>
+    \[1\]\s*=>
     string\(3\) "cat"
-    \[2\] =>
+    \[2\]\s*=>
     string\(4\) "bird"
   \}
 

--- a/lib/Transphpile/Tests/Functional/tests/doublecall001.yml
+++ b/lib/Transphpile/Tests/Functional/tests/doublecall001.yml
@@ -10,7 +10,7 @@ code: |
   }
 
   class C{
-    function test2() {
+    static function test2() {
       return function($arg, $arg2) { return $arg + $arg2; };
     }
   }

--- a/lib/Transphpile/Tests/FunctionalTestCase.php
+++ b/lib/Transphpile/Tests/FunctionalTestCase.php
@@ -68,7 +68,7 @@ class FunctionalTestCase extends TestCase
             $config['stderr'] = trim($config['stderr']);
 
             if (empty($stderr)) {
-                $this->fail("stderr seems empty but should contain an error\nconfig:\n$config\n\nstdout:\n$stdout\n");
+                $this->fail(sprintf("stderr seems empty but should contain an error\nconfig:\n%s\n\nstdout:\n%s\n", var_export($config, true), $stdout));
             }
             $this->assertRegExp('{'.$config['stderr'].'}', $stderr, isset($config['name']) ? $config['name'] : "");
         }

--- a/lib/Transphpile/Tests/FunctionalTestCase.php
+++ b/lib/Transphpile/Tests/FunctionalTestCase.php
@@ -55,7 +55,7 @@ class FunctionalTestCase extends TestCase
 
         // If we don't define stderr, there should not be any stderr output from our php5 file
         if (! empty($stderr) && ! isset($config['stderr'])) {
-            $this->fail('Error reported, but no stderr section found in $yamlPath');
+            $this->fail("Error reported, but no stderr section found in $yamlPath\nError: $stderr\n");
         }
 
         // Check output
@@ -63,11 +63,12 @@ class FunctionalTestCase extends TestCase
         $this->assertRegExp('{'.$config['stdout'].'}', $stdout, isset($config['name']) ? $config['name'] : "");
 
         // Check stderr if any
+        // (When running this test, make sure that the ini setting display_errors=stderr is set)
         if (isset($config['stderr'])) {
             $config['stderr'] = trim($config['stderr']);
 
             if (empty($stderr)) {
-                $this->fail('stderr seems empty but should contain an error');
+                $this->fail("stderr seems empty but should contain an error\nconfig:\n$config\n\nstdout:\n$stdout\n");
             }
             $this->assertRegExp('{'.$config['stderr'].'}', $stderr, isset($config['name']) ? $config['name'] : "");
         }

--- a/lib/Transphpile/Tests/phprc/README.md
+++ b/lib/Transphpile/Tests/phprc/README.md
@@ -1,0 +1,4 @@
+By setting the environment variable PHPRC to the folder of this readme and php.ini,
+the php.ini used for tests can be overridden, resulting in consistent test results.
+
+NOTE: /etc/php.d/ may still contain other overrides.

--- a/lib/Transphpile/Tests/phprc/php.ini
+++ b/lib/Transphpile/Tests/phprc/php.ini
@@ -1,3 +1,6 @@
 error_reporting=E_ALL
 display_errors=stderr
 date.timezone=UTC
+; Travis will enable xdebug, which adds file (stdin, i.e. "-") and line by default.
+; Disable that.
+xdebug.overload_var_dump=0

--- a/lib/Transphpile/Tests/phprc/php.ini
+++ b/lib/Transphpile/Tests/phprc/php.ini
@@ -1,0 +1,3 @@
+error_reporting=E_ALL
+display_errors=stderr
+date.timezone=UTC

--- a/lib/Transphpile/Transpile/Visitors/Php70/NullCoalesceVisitor.php
+++ b/lib/Transphpile/Transpile/Visitors/Php70/NullCoalesceVisitor.php
@@ -10,18 +10,28 @@ use PhpParser\NodeVisitorAbstract;
  * Converts $a ?? $b into:
  *
  *      call_user_func(
- *          function ($v1, $v2) { return isset($v1) ? $v1 : $v2; },
- *          @$a,
- *          @$b
+ *          function($v1) { return $v1[0]; },
+ *          call_user_func(
+ *              function($v1) { return $v1 !== null ? array($v1) : null; },
+ *              @$a
+ *          ) ?: [$b]
  *      )
  *
- * This construct is needed because isset() only works on variables, while the null coalesce supports any expression.
+ * (Can't use (expr)[0] in php 5.6)
+ * (Can't use reset(expr) in php 7.0+ without a warning about taking a reference on non-reference)
+ *
+ * This construct is sometimes needed because isset() only works on variables, while the null coalesce supports any expression.
  * We also add a @ operator to the variable, in case it doesn't exist so it does not throw a notice.
  *
+ * TODO: Can optimize/simplify the cases where the left hand side is always simple,
+ * and avoid method calls (Assume ArrayAccess is implemented properly).
+ *
+ * - e.g. convert `$x->y['key'] ?? DEFAULT` into `isset($x->y['key']) ? $x->y['key'] : DEFAULT`
  */
 
 class NullCoalesceVisitor extends NodeVisitorAbstract
 {
+
     public function leaveNode(Node $node)
     {
         if (!$node instanceof Node\Expr\BinaryOp\Coalesce) {
@@ -29,10 +39,9 @@ class NullCoalesceVisitor extends NodeVisitorAbstract
         }
 
         // Create closure node
-        $closureNode = new Node\Expr\Closure(array(
+        $closureLHSNode = new Node\Expr\Closure(array(
             'params' => array(
                 new Node\Param('v1'),
-                new Node\Param('v2'),
             ),
             'stmts' => array(
                 new Node\Stmt\Return_(
@@ -40,23 +49,61 @@ class NullCoalesceVisitor extends NodeVisitorAbstract
                         new Node\Expr\Isset_(array(
                             new Node\Expr\Variable('v1'),
                         )),
-                        new Node\Expr\Variable('v1'),
-                        new Node\Expr\Variable('v2')
+                        new Node\Expr\Array_([
+                            new Node\Expr\ArrayItem(
+                                new Node\Expr\Variable('v1')
+                            ),
+                        ]),
+                        new Node\Expr\ConstFetch(new Node\Name('null'))
                     )
                 )
             )
         ));
 
         // Create call_user_func() call
-        $callUserFuncNode = new Node\Expr\FuncCall(
-            new Node\Name('call_user_func'),
+        // Implementation of coalesce LHS
+        $coalesceLhs = new Node\Expr\FuncCall(
+            new Node\Name\FullyQualified('call_user_func'),
             array(
-                $closureNode,
+                $closureLHSNode,
                 new Node\Expr\ErrorSuppress($node->left),
-                new Node\Expr\ErrorSuppress($node->right),
             )
         );
 
-        return $callUserFuncNode;
+        $inner = new Node\Expr\Ternary($coalesceLhs, null, new Node\Expr\Array_([
+            new Node\Expr\ArrayItem(
+                $node->right
+            ),
+        ]));
+
+        return $this->buildGetFirstElement($inner);
+    }
+
+    /**
+     * @return Node PHP code to fetch the first element
+     */
+    private function buildGetFirstElement(Node $node) {
+        // This closure does the same thing as `new Node\Name\FullyQualified('reset')`
+        // but avoids the notice about taking a reference of a non-reference in php7.0+
+        $closureLHSNode = new Node\Expr\Closure(array(
+            'params' => array(
+                new Node\Param('v1'),
+            ),
+            'stmts' => array(
+                new Node\Stmt\Return_(
+                    new Node\Expr\ArrayDimFetch(
+                        new Node\Expr\Variable('v1'),
+                        new Node\Scalar\LNumber(0)
+                    )
+                )
+            )
+        ));
+        return new Node\Expr\FuncCall(
+            new Node\Name\FullyQualified('call_user_func'),
+            array(
+                $closureLHSNode,
+                $node,
+            )
+        );
     }
 }


### PR DESCRIPTION
It's possible to optimize the special cases.
`reset()` wasn't used because that would emit a warning in php7 if
non-references were used.

Motivation: if the right hand size can throw,
then the transpiled code should only evaluate the right hand side
if the left hand side is `null`.
(E.g. `foo($args) ?? bar($otherargs)`, `bar` may throw)

E.g. this converts `$x = $y ?? 2` into the below expression
(`?:` is the only operator which evaluates the left hand side once
and conditionally evaluates the right hand side)
- The empty array is falsey, the non-empty array is always truthy

```php
$x = \call_user_func(function ($v1) {
    return $v1[0];
}, \call_user_func(function ($v1) {
    return isset($v1) ? array($v1) : null;
}, @$y) ?: array(2));
```

EDIT: Forgot that should be call_user_func on the outside