### PR TITLE
Fixes #20: Generate correct code for function test(int ...$args)

### DIFF
--- a/lib/Transphpile/Tests/Functional/tests/typehint006.yml
+++ b/lib/Transphpile/Tests/Functional/tests/typehint006.yml
@@ -1,0 +1,19 @@
+---
+name: test if scalar typehint works
+stdout: |
+  523
+stderr: |
+  Argument \$arg passed to test\(\) must be of the type int, string given
+code: |
+  declare(strict_types=1);
+
+  function test(int ...$arg) {
+      foreach ($arg as $v) {
+          print $v;
+      }
+  }
+
+  test(5, 2);
+  test();
+  test(3);
+  test(1, "6");

--- a/lib/Transphpile/Tests/FunctionalTestCase.php
+++ b/lib/Transphpile/Tests/FunctionalTestCase.php
@@ -60,7 +60,7 @@ class FunctionalTestCase extends TestCase
 
         // Check output
         $config['stdout'] = trim($config['stdout']);
-        $this->assertRegExp('{'.$config['stdout'].'}', $stdout, isset($config['name']) ? $config['name'] : "");
+        $this->assertRegExp('{'.$config['stdout'].'}', $stdout, (isset($config['name']) ? $config['name'] : "") . ": stderr:\n$stderr");
 
         // Check stderr if any
         if (isset($config['stderr'])) {

--- a/lib/Transphpile/Transpile/Visitors/Php70/ReturnVisitor.php
+++ b/lib/Transphpile/Transpile/Visitors/Php70/ReturnVisitor.php
@@ -80,7 +80,7 @@ class ReturnVisitor extends NodeVisitorAbstract
                 $returnType, $returnType
             );
         } else {
-            // Otherwise use is_a for check against classes
+            // Otherwise use instanceof for check against classes
             $code = sprintf(
                 '<?php '."\n".
                 '  if ('.$nullCheck.' ! $'.$retVar.' instanceof %s) { '."\n".


### PR DESCRIPTION
Also, include stderr for error messages of tests failures, to make debugging failures easier when stdout is wrong

PHP's error message (in 7.1) would say "argument 1" or "argument 2" instead of "argument $arg", didn't seem important for varargs and $arg is already being used in messages